### PR TITLE
SUMMIT #272: EG14 v2 (16/16) — supply-chain + RLS gates

### DIFF
--- a/docs/ENTERPRISE-GRADE-FEATURE-POLICY.md
+++ b/docs/ENTERPRISE-GRADE-FEATURE-POLICY.md
@@ -9,9 +9,9 @@
 
 ## The Rule
 
-Every feature built from competitive weakness analysis must preserve or improve the EG14 14/14 lock on the production domain. No feature is considered shipped until the live homepage passes all 14 enterprise-grade checks post-merge.
+Every feature built from competitive weakness analysis must preserve or improve the EG14 16/16 lock on the production domain. No feature is considered shipped until the live homepage passes all 16 enterprise-grade checks post-merge.
 
-**`<14/14 = WIP = 0`**
+**`<16/16 = WIP = 0`**
 
 ## What triggers this gate
 
@@ -25,7 +25,7 @@ Any SUMMIT, PR, or direct commit that:
 
 ## The 14 checks (SSOT)
 
-See `docs/EVEREST-GATE.md` for the canonical list. As of 2026-04-09 the 14 checks are:
+See `docs/EVEREST-GATE.md` for the canonical list. As of 2026-04-09 the 16 checks are:
 
 1. HTTP 200 on `/`
 2. Lighthouse Performance ≥ 90
@@ -41,17 +41,19 @@ See `docs/EVEREST-GATE.md` for the canonical list. As of 2026-04-09 the 14 check
 12. Meta tags valid (Open Graph, Twitter, canonical)
 13. Structured data valid (JSON-LD)
 14. Sitemap + robots valid and served
+15. Supply-chain clean (`npm audit --omit=dev --audit-level=high` exits 0)
+16. RLS coverage (`select count(*) from public.zw_rls_audit()` returns 0)
 
 ## Enforcement Protocol
 
 ### For SUMMIT dispatches
 
-Every SUMMIT issue body MUST include a **Deliverable N — EG14 14/14 Gate** section as the final blocking deliverable. The gate section must specify:
+Every SUMMIT issue body MUST include a **Deliverable N — EG14 16/16 Gate** section as the final blocking deliverable. The gate section must specify:
 
 - Exact workflow dispatch command
 - Poll interval and timeout
 - Supabase query for `eg14_runs` verification
-- Three outcome branches (A: 14/14 complete, B: regression fix loop, C: timeout retry)
+- Three outcome branches (A: 16/16 complete, B: regression fix loop, C: timeout retry)
 - No Telegram report until EG14 has a verdict
 
 ### For direct commits
@@ -71,7 +73,7 @@ When Claude Code is building from a SUMMIT issue, it must:
 2. Dispatch EG14 after the final deliverable lands
 3. Wait for the verdict (do not mark the SUMMIT complete mid-verdict)
 4. Execute outcome branch A, B, or C based on the result
-5. Only send the completion Telegram after EG14 returns 14/14 or after 3 failed retries
+5. Only send the completion Telegram after EG14 returns 16/16 or after 3 failed retries
 
 ### For emergency rollbacks
 
@@ -84,7 +86,7 @@ If a regression is discovered on the live site:
 
 ## Rationale
 
-The competitive weakness analysis process (PropZone, Algoma, MapWise, Zoneomics, etc.) continuously generates new feature requirements. Each new feature touches the production surface. Without an enforcement gate, incremental drift from the 14/14 lock is inevitable — new console errors from third-party dependencies, bundle size growth from new components, security header drift from middleware edits, brand guard violations from hasty UI work.
+The competitive weakness analysis process (PropZone, Algoma, MapWise, Zoneomics, etc.) continuously generates new feature requirements. Each new feature touches the production surface. Without an enforcement gate, incremental drift from the 16/16 lock is inevitable — new console errors from third-party dependencies, bundle size growth from new components, security header drift from middleware edits, brand guard violations from hasty UI work.
 
 The alternative — "ship moat, fix quality later" — produces exactly the opposite of an enterprise-grade product. PropZone can be beaten on KPI count. It cannot be beaten on KPI count AND broken pages AND 60-perf Lighthouse. We compete on the entire experience.
 
@@ -116,7 +118,7 @@ The alternative — "ship moat, fix quality later" — produces exactly the oppo
 
 ### The Rule
 
-When a SUMMIT closes a gap listed in any competitor battle card, the card MUST be refreshed in the same SUMMIT commit, **before** the EG14 14/14 gate. The refresh happens in the same branch as the feature so the live card reflects the new reality the moment EG14 passes.
+When a SUMMIT closes a gap listed in any competitor battle card, the card MUST be refreshed in the same SUMMIT commit, **before** the EG14 16/16 gate. The refresh happens in the same branch as the feature so the live card reflects the new reality the moment EG14 passes.
 
 ### What "refresh" means concretely
 
@@ -171,7 +173,7 @@ SUMMITs that ship features without refreshing the relevant battle card are marke
 | #404 Mapbox tiles | 50W / 1L / 29T | +1 parity (ZON-022) | 50W / 1L / 30T |
 | #405 Water setback | 50W / 1L / 30T | -1 gap, +1 parity (ZON-023) | **50W / 0L / 31T** |
 
-Each row reflects a battle card commit in the same SUMMIT as the feature ship. No SUMMIT is marked complete until both the feature AND the card update are live AND EG14 returns 14/14.
+Each row reflects a battle card commit in the same SUMMIT as the feature ship. No SUMMIT is marked complete until both the feature AND the card update are live AND EG14 returns 16/16.
 
 ### Applies to all 11 competitors
 

--- a/docs/EVEREST-GATE.md
+++ b/docs/EVEREST-GATE.md
@@ -1,15 +1,15 @@
-# EVEREST GATE — Enterprise-Grade 14-Point Verification (EG14)
+# EVEREST GATE — Enterprise-Grade 16-Point Verification (EG14 v2)
 
 **Status:** PERMANENT • Authoritative • SSOT for all SUMMIT shipping criteria
 **Owner:** Claude AI Architect
-**Established:** Mar 30 2026 • Codified: Apr 8 2026
+**Established:** Mar 30 2026 • Codified: Apr 8 2026 • **v2: Apr 9 2026 (SUMMIT #272)**
 **Supersedes:** All prior "shipped" / "WIP" / "verified" definitions
 
 ---
 
 ## Definition
 
-**EVEREST GATE (EG14)** is the 14-point enterprise-grade verification every SUMMIT must pass before claiming task satisfaction. No SUMMIT closes without **14/14 PASS** against the **production domain** (zonewise.ai or biddeed.ai), evidenced by Playwright screenshots stored in Supabase and posted as a comment on the originating issue.
+**EVEREST GATE (EG14 v2)** is the 16-point enterprise-grade verification every SUMMIT must pass before claiming task satisfaction. No SUMMIT closes without **16/16 PASS** against the **production domain** (zonewise.ai or biddeed.ai), evidenced by Playwright screenshots stored in Supabase and posted as a comment on the originating issue.
 
 **Verified delivery is the moat.** Anything less = WIP=0, SUMMIT reopens.
 
@@ -33,6 +33,8 @@
 | 12 | **API Health** | All /api/* routes touched by the feature return 200 with valid payload | curl loop log |
 | 13 | **Supabase Integrity** | Required tables exist, RLS policies set, RPCs callable | psql/REST verification |
 | 14 | **Cross-Browser** | Chromium + Firefox + WebKit at 1920x1080 — no layout breaks, feature works in all 3 | 3 Playwright screenshots |
+| 15 | **Supply-Chain Clean** | `npm audit --omit=dev --audit-level=high` exits 0. No high/critical vulnerabilities in production dependencies. | CI job output (SUMMIT #272) |
+| 16 | **RLS Coverage** | `select count(*) from public.zw_rls_audit()` returns 0. Every public table has RLS enabled with at least one policy. | psql query result (SUMMIT #272) |
 
 **Bonus (mandatory but not numbered):** Core Web Vitals — LCP <2.5s, CLS <0.1, INP <200ms.
 
@@ -40,8 +42,8 @@
 
 ## Pass / Fail Rules
 
-- **PASS = 14/14**, no exceptions. 13/14 = WIP=0, reopens automatically.
-- Any FAIL on points 1, 6, 8, 11 = **CRITICAL**, blocks all promotion.
+- **PASS = 16/16**, no exceptions. 15/16 = WIP=0, reopens automatically.
+- Any FAIL on points 1, 6, 8, 11, 15, 16 = **CRITICAL**, blocks all promotion.
 - Points 2 (Lighthouse) and 4 (axe) require numerical evidence files in Supabase.
 - All screenshots must be of the **production domain** (zonewise.ai / biddeed.ai), NOT vercel.app preview, NOT /labs/*.
 
@@ -56,7 +58,7 @@ SUMMIT dispatch
   → PR opened
   → Promote to production via promote-now.yml
   → EVEREST GATE runs (14-point Playwright suite)
-  → 14/14? → comment screenshots + close SUMMIT
+  → 16/16? → comment screenshots + close SUMMIT
   → <14? → AUTOLOOP V2: signal_detector → evolver → patch → redeploy → re-run gate (max 3 loops)
   → Still <14 after 3 loops? → BLOCKED comment, escalate
 ```
@@ -93,7 +95,7 @@ Every SUMMIT spec MUST include:
 - Long form: **EVEREST GATE**
 - Short form: **EG14**
 - Reference in commits: `eg14:` prefix (e.g., `eg14: pass 12/14, mobile overflow + lighthouse 87`)
-- Reference in SUMMIT comments: `EVEREST GATE 14/14 ✅` or `EVEREST GATE 11/14 — see eg14_runs`
+- Reference in SUMMIT comments: `EVEREST GATE 16/16 ✅` or `EVEREST GATE 11/14 — see eg14_runs`
 
 ---
 


### PR DESCRIPTION
## Summary
- Expands EVEREST GATE from 14/14 to **16/16**
- **#15 Supply-chain clean:** `npm audit --omit=dev --audit-level=high` exits 0 — CRITICAL
- **#16 RLS coverage:** `select count(*) from public.zw_rls_audit()` returns 0 — CRITICAL
- Updates both `EVEREST-GATE.md` and `ENTERPRISE-GRADE-FEATURE-POLICY.md`

## Test plan
- [ ] Verify EVEREST-GATE.md table has 16 rows
- [ ] Verify pass/fail rules reference 16/16
- [ ] Verify ENTERPRISE-GRADE-FEATURE-POLICY.md references 16/16

Ref: #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)