### PR TITLE
fix: replace dead auction URLs (vweb2.brevardclerk + bare realforeclose)

### DIFF
--- a/auction/agent-harness/cli_anything/auction/core/discovery.py
+++ b/auction/agent-harness/cli_anything/auction/core/discovery.py
@@ -27,7 +27,7 @@ SAMPLE_CASES = [
      "judgment": 98000, "plaintiff": "HOA Sunset Palms", "auction_date": "2026-03-15"},
 ]
 
-REALFORECLOSE_URL = "https://www.realforeclose.com/index.cfm"
+REALFORECLOSE_URL = "https://brevard.realforeclose.com/index.cfm"
 RF_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
                   "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",

--- a/docs/plans/SUMMIT-EVEREST-SQUAD-REALFORECLOSE.md
+++ b/docs/plans/SUMMIT-EVEREST-SQUAD-REALFORECLOSE.md
@@ -39,7 +39,7 @@ RealForeclose DAYLIST (public, no auth)
     │
     ▼
 ┌─────────────────────────────┐
-│ 1. SCOUT: Discovery         │ GET www.realforeclose.com/index.cfm
+│ 1. SCOUT: Discovery         │ GET brevard.realforeclose.com/index.cfm
 │    ?zession=day_list        │   ?county=brevard&sale_type=fc
 │    Parse HTML table         │   &sale_date=MM/DD/YYYY
 │    Extract: case_number,    │
@@ -84,7 +84,7 @@ RealForeclose DAYLIST (public, no auth)
 
 ```python
 # Key endpoint (NO AUTH REQUIRED — public results page):
-# https://www.realforeclose.com/index.cfm?zession=day_list&county=brevard&sale_type=fc&sale_date=04/14/2024
+# https://brevard.realforeclose.com/index.cfm?zession=day_list&county=brevard&sale_type=fc&sale_date=04/14/2024
 
 # Existing working code to port FROM:
 # brevard-bidder-scraper/src/scrapers/historical_results_scraper.py
@@ -190,7 +190,7 @@ def estimate_arv(case_data: dict) -> float:
 
 ```yaml
 realforeclose_daylist:
-  url: "https://www.realforeclose.com/index.cfm"
+  url: "https://brevard.realforeclose.com/index.cfm"
   params:
     zession: day_list
     county: brevard


### PR DESCRIPTION
## Summary\n- Replaces dead `vweb2.brevardclerk.us` URLs with working `www.brevardclerk.us`\n- Replaces dead bare `www.realforeclose.com` / `realforeclose.com/index.cfm?county=15` with per-county `brevard.realforeclose.com` subdomain\n- Part of SUMMIT #432 — Brevard Auction Data Freshness Triage\n\n## Context\n- `vweb2.brevardclerk.us` HTTPS is ERR_CONNECTION_REFUSED (dead over HTTPS)\n- `www.realforeclose.com` / bare `realforeclose.com` DNS is dead (ERR_NAME_NOT_RESOLVED)\n- Verified replacements return HTTP 200 from Hetzner\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)