### PR TITLE
fix(summit): harden issues input validation, remove dead #379 default

### DIFF
--- a/.github/workflows/claude-code-direct.yml
+++ b/.github/workflows/claude-code-direct.yml
@@ -3,11 +3,22 @@ on:
   workflow_dispatch:
     inputs:
       issues:
-        description: 'Comma-separated issue numbers'
+        description: 'Comma-separated issue numbers (REQUIRED, no default — empty = hard fail)'
         required: true
-        default: '379'
+        type: string
 jobs:
+  validate-input:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject empty or missing issues input
+        run: |
+          if [ -z "${{ inputs.issues }}" ]; then
+            echo "::error::Empty 'issues' input. Dispatch rejected."
+            exit 1
+          fi
+          echo "::notice::SUMMIT dispatch received issues input: ${{ inputs.issues }}"
   run-claude-code:
+    needs: validate-input
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -15,6 +26,51 @@ jobs:
         issue: ${{ fromJson(format('[{0}]', inputs.issues)) }}
       fail-fast: false
     steps:
+      - name: Validate issue input
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          ISSUE: ${{ matrix.issue }}
+          ALLOW_PLACEHOLDER: ${{ vars.ALLOW_PLACEHOLDER }}
+        run: |
+          set -e
+          # Guard against empty/whitespace
+          if [ -z "${ISSUE// /}" ]; then
+            echo "::error::Empty issue number passed to workflow. Dispatch must supply non-empty 'issues' input."
+            exit 1
+          fi
+          # Guard against non-numeric
+          if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+            echo "::error::Issue number '$ISSUE' is not a positive integer."
+            exit 1
+          fi
+          # Guard against dead placeholder #379 (unless explicitly allowed by override)
+          if [ "$ISSUE" = "379" ] && [ "${ALLOW_PLACEHOLDER:-0}" != "1" ]; then
+            echo "::error::Refusing to run against dead placeholder issue #379. If intentional, set vars.ALLOW_PLACEHOLDER=1."
+            exit 1
+          fi
+          # Verify issue exists and is open
+          STATUS=$(curl -s -o /tmp/iss.json -w "%{http_code}" -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/breverdbidder/cli-anything-biddeed/issues/$ISSUE")
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Issue #$ISSUE does not exist (HTTP $STATUS)."
+            exit 1
+          fi
+          STATE=$(python3 -c "import json; print(json.load(open('/tmp/iss.json'))['state'])")
+          if [ "$STATE" != "open" ]; then
+            echo "::error::Issue #$ISSUE is not open (state=$STATE). Refusing to run."
+            exit 1
+          fi
+          # Verify it has the 'summit' label
+          HAS_SUMMIT=$(python3 -c "import json; d=json.load(open('/tmp/iss.json')); print('yes' if any(l['name']=='summit' for l in d.get('labels',[])) else 'no')")
+          if [ "$HAS_SUMMIT" != "yes" ]; then
+            echo "::warning::Issue #$ISSUE does not have 'summit' label. Proceeding anyway but flagging."
+          fi
+          echo "✅ Issue #$ISSUE validated: open, summit-labeled, ready."
+
+      - name: Announce dispatch target
+        run: |
+          echo "::notice::SUMMIT dispatching against issue(s): ${{ inputs.issues }} → matrix element ${{ matrix.issue }}"
+
       - name: Run Claude Code on Hetzner for issue ${{ matrix.issue }}
         env:
           HETZNER_IP: ${{ secrets.HETZNER_IP }}

--- a/docs/SUMMIT-DISPATCH.md
+++ b/docs/SUMMIT-DISPATCH.md
@@ -1,0 +1,90 @@
+# SUMMIT Dispatch Guide
+
+## How to Dispatch
+
+### Via GitHub CLI (recommended)
+
+```bash
+# Single issue
+gh workflow run claude-code-direct.yml -f issues=440
+
+# Multiple issues (parallel)
+gh workflow run claude-code-direct.yml -f issues="440,441,442"
+```
+
+### Via GitHub API
+
+```bash
+curl -X POST \
+  -H "Authorization: token $GH_PAT" \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/breverdbidder/cli-anything-biddeed/actions/workflows/claude-code-direct.yml/dispatches \
+  -d '{"ref":"main","inputs":{"issues":"440"}}'
+```
+
+### Via GitHub UI
+
+1. Go to Actions > "Claude Code Direct — Parallel SUMMITs"
+2. Click "Run workflow"
+3. Enter comma-separated issue numbers (e.g., `440,441`)
+4. Click "Run workflow"
+
+## Input Validation
+
+The workflow validates every issue number before running Claude Code on Hetzner. Validation happens in two stages:
+
+### Stage 1: `validate-input` job
+
+Runs before any matrix expansion. Rejects the entire dispatch if `issues` input is empty.
+
+### Stage 2: Per-issue validation (first step in each matrix job)
+
+Each matrix element is checked for:
+
+| Check | Behavior on failure |
+|-------|-------------------|
+| Empty/whitespace | Hard fail with `::error` |
+| Non-numeric value | Hard fail with `::error` |
+| Issue #379 (dead placeholder) | Hard fail unless `ALLOW_PLACEHOLDER=1` |
+| Issue does not exist (HTTP != 200) | Hard fail with `::error` |
+| Issue is not open | Hard fail with `::error` |
+| Missing `summit` label | Warning only, proceeds |
+
+## Validation Error Messages
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Empty 'issues' input` | Dispatch sent with blank issues field | Supply at least one issue number |
+| `Empty issue number passed to workflow` | Matrix element resolved to empty string | Check comma formatting (no trailing commas) |
+| `Issue number 'X' is not a positive integer` | Non-numeric value in issues list | Use only integer issue numbers |
+| `Refusing to run against dead placeholder issue #379` | Issue #379 is a dead placeholder | Use a real issue number, or set `ALLOW_PLACEHOLDER=1` |
+| `Issue #X does not exist` | GitHub API returned non-200 | Verify the issue number exists in the repo |
+| `Issue #X is not open` | Issue is closed | Reopen the issue or use an open one |
+
+## Escape Hatches
+
+### Running against #379 intentionally
+
+If you genuinely need to test against the placeholder issue #379:
+
+1. Go to repo Settings > Secrets and variables > Actions > Variables
+2. Add or set `ALLOW_PLACEHOLDER` = `1`
+3. Dispatch normally
+4. Remove the variable after testing
+
+## Architecture
+
+```
+dispatch(issues="440,441")
+  |
+  +- validate-input job (ubuntu-latest, ~5s)
+  |   +- Reject if issues is empty
+  |
+  +- run-claude-code job (needs: validate-input)
+      +- matrix: [440, 441]
+      |
+      +- [440] Validate -> Announce -> SSH Hetzner -> Claude Code
+      +- [441] Validate -> Announce -> SSH Hetzner -> Claude Code
+```
+
+Each matrix element runs independently with `fail-fast: false` — one failing issue does not cancel others.


### PR DESCRIPTION
## Summary

Closes #440

1. **Removed `default: '379'`** — empty dispatch now hard-fails instead of silently targeting dead placeholder
2. **Added `validate-input` job** — gates matrix expansion, rejects empty input before any Hetzner SSH
3. **Added per-issue validation step** — checks: non-empty, numeric, not #379, issue exists, issue is open, has summit label
4. **Added dispatch announcement** — `::notice` annotation with resolved issue numbers
5. **Created `docs/SUMMIT-DISPATCH.md`** — dispatch guide with API/CLI/UI examples, error reference, escape hatches

## Test plan

- [ ] Dispatch with empty `issues` input via API -> should fail at `validate-input` job
- [ ] Dispatch with `issues=440` -> should pass validation and proceed to Hetzner
- [ ] Dispatch with `issues=379` -> should fail with placeholder guard error
- [ ] Dispatch with `issues=999999` -> should fail with "does not exist" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)