### PR TITLE
fix(summit): harden issues input validation, remove dead #379 default

### DIFF
--- a/.github/workflows/claude-code-direct.yml
+++ b/.github/workflows/claude-code-direct.yml
@@ -3,11 +3,22 @@ on:
   workflow_dispatch:
     inputs:
       issues:
-        description: 'Comma-separated issue numbers'
+        description: 'Comma-separated issue numbers (REQUIRED, no default — empty = hard fail)'
         required: true
-        default: '379'
+        type: string
 jobs:
+  validate-input:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject empty issues input
+        run: |
+          if [ -z "${{ inputs.issues }}" ]; then
+            echo "::error::Empty 'issues' input. Dispatch rejected."
+            exit 1
+          fi
+          echo "::notice::SUMMIT dispatch received issues input: ${{ inputs.issues }}"
   run-claude-code:
+    needs: validate-input
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -15,6 +26,48 @@ jobs:
         issue: ${{ fromJson(format('[{0}]', inputs.issues)) }}
       fail-fast: false
     steps:
+      - name: Validate issue input
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          ISSUE: ${{ matrix.issue }}
+          ALLOW_PLACEHOLDER: ${{ vars.ALLOW_PLACEHOLDER }}
+        run: |
+          set -e
+          echo "::notice::SUMMIT dispatching against issue(s): ${{ inputs.issues }} → matrix element ${{ matrix.issue }}"
+          # Guard against empty/whitespace
+          if [ -z "${ISSUE// /}" ]; then
+            echo "::error::Empty issue number passed to workflow. Dispatch must supply non-empty 'issues' input."
+            exit 1
+          fi
+          # Guard against non-numeric
+          if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+            echo "::error::Issue number '$ISSUE' is not a positive integer."
+            exit 1
+          fi
+          # Guard against dead placeholder #379 (unless explicitly allowed by override)
+          if [ "$ISSUE" = "379" ] && [ "${ALLOW_PLACEHOLDER:-0}" != "1" ]; then
+            echo "::error::Refusing to run against dead placeholder issue #379. If intentional, set vars.ALLOW_PLACEHOLDER=1."
+            exit 1
+          fi
+          # Verify issue exists and is open
+          STATUS=$(curl -s -o /tmp/iss.json -w "%{http_code}" -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/breverdbidder/cli-anything-biddeed/issues/$ISSUE")
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Issue #$ISSUE does not exist (HTTP $STATUS)."
+            exit 1
+          fi
+          STATE=$(python3 -c "import json; print(json.load(open('/tmp/iss.json'))['state'])")
+          if [ "$STATE" != "open" ]; then
+            echo "::error::Issue #$ISSUE is not open (state=$STATE). Refusing to run."
+            exit 1
+          fi
+          # Verify it has the 'summit' label
+          HAS_SUMMIT=$(python3 -c "import json; d=json.load(open('/tmp/iss.json')); print('yes' if any(l['name']=='summit' for l in d.get('labels',[])) else 'no')")
+          if [ "$HAS_SUMMIT" != "yes" ]; then
+            echo "::warning::Issue #$ISSUE does not have 'summit' label. Proceeding anyway but flagging."
+          fi
+          echo "✅ Issue #$ISSUE validated: open, ready."
+
       - name: Run Claude Code on Hetzner for issue ${{ matrix.issue }}
         env:
           HETZNER_IP: ${{ secrets.HETZNER_IP }}
@@ -29,12 +82,20 @@ jobs:
           SSH="ssh -i ~/.ssh/key -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o BatchMode=yes root@${HETZNER_IP}"
 
           echo "=== Setup workspace ==="
-          $SSH "mkdir -p /root/summit-${ISSUE} && cd /root/summit-${ISSUE} &&             (test -d zonewise-web/.git && cd zonewise-web && git pull ||             git clone https://x-access-token:${GH_PAT}@github.com/breverdbidder/zonewise-web.git) &&             cd zonewise-web && git config user.email 'claude-code@biddeed.ai' && git config user.name 'Claude Code'"
+          $SSH "mkdir -p /root/summit-${ISSUE} && cd /root/summit-${ISSUE} && \
+            (test -d zonewise-web/.git && cd zonewise-web && git pull || \
+            git clone https://x-access-token:${GH_PAT}@github.com/breverdbidder/zonewise-web.git) && \
+            cd zonewise-web && git config user.email 'claude-code@biddeed.ai' && git config user.name 'Claude Code'"
 
           echo "=== Verify OAuth is alive (DO NOT delete credentials) ==="
           $SSH "test -f /root/.claude/credentials.json && echo 'OAuth credentials found' || test -f /root/.claude/.credentials.json && echo 'OAuth credentials found' || echo 'WARNING: No OAuth credentials'"
 
           echo "=== Run Claude Code on SUMMIT #${ISSUE} (using Max plan OAuth) ==="
-          $SSH "cd /root/summit-${ISSUE}/zonewise-web &&             export SUPABASE_ACCESS_TOKEN='${SUPABASE_ACCESS_TOKEN}' &&             export GH_PAT='${GH_PAT}' &&             claude -p 'Read GitHub issue #${ISSUE} at https://github.com/breverdbidder/cli-anything-biddeed/issues/${ISSUE} using: curl -s -H \"Authorization: token ${GH_PAT}\" https://api.github.com/repos/breverdbidder/cli-anything-biddeed/issues/${ISSUE} | jq .body. Also read all comments: curl -s -H \"Authorization: token ${GH_PAT}\" https://api.github.com/repos/breverdbidder/cli-anything-biddeed/issues/${ISSUE}/comments | jq .[].body. Then execute ALL tasks. Follow CLAUDE.md. Commit and push frequently. Comment on the issue when done.'             --allowedTools 'Bash(*)' 'Read' 'Write' 'Edit'             2>&1 | tail -500" || echo "Claude Code session ended"
+          $SSH "cd /root/summit-${ISSUE}/zonewise-web && \
+            export SUPABASE_ACCESS_TOKEN='${SUPABASE_ACCESS_TOKEN}' && \
+            export GH_PAT='${GH_PAT}' && \
+            claude -p 'Read GitHub issue #${ISSUE} at https://github.com/breverdbidder/cli-anything-biddeed/issues/${ISSUE} using: curl -s -H \"Authorization: token ${GH_PAT}\" https://api.github.com/repos/breverdbidder/cli-anything-biddeed/issues/${ISSUE} | jq .body. Also read all comments: curl -s -H \"Authorization: token ${GH_PAT}\" https://api.github.com/repos/breverdbidder/cli-anything-biddeed/issues/${ISSUE}/comments | jq .[].body. Then execute ALL tasks. Follow CLAUDE.md. Commit and push frequently. Comment on the issue when done.' \
+            --allowedTools 'Bash(*)' 'Read' 'Write' 'Edit' \
+            2>&1 | tail -500" || echo "Claude Code session ended"
 
           echo "=== SUMMIT #${ISSUE} COMPLETE ==="

--- a/docs/SUMMIT-DISPATCH.md
+++ b/docs/SUMMIT-DISPATCH.md
@@ -1,0 +1,72 @@
+# SUMMIT Dispatch — Usage & Validation Reference
+
+## How to Dispatch
+
+### Via GitHub CLI
+
+```bash
+# Single issue
+gh workflow run "Claude Code Direct — Parallel SUMMITs" \
+  -R breverdbidder/cli-anything-biddeed \
+  -f issues=440
+
+# Multiple issues (parallel matrix)
+gh workflow run "Claude Code Direct — Parallel SUMMITs" \
+  -R breverdbidder/cli-anything-biddeed \
+  -f issues="440,441,442"
+```
+
+### Via GitHub API
+
+```bash
+curl -X POST \
+  -H "Authorization: token $GH_PAT" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/breverdbidder/cli-anything-biddeed/actions/workflows/claude-code-direct.yml/dispatches" \
+  -d '{"ref":"main","inputs":{"issues":"440"}}'
+```
+
+## Validation Checks
+
+The workflow runs two layers of validation before any Hetzner SSH or Claude Code invocation:
+
+### 1. Pre-matrix validation (`validate-input` job)
+
+Runs before the matrix expands. Catches:
+
+| Error | Meaning |
+|-------|---------|
+| `Empty 'issues' input. Dispatch rejected.` | You dispatched with `issues=""` or omitted it entirely. Supply at least one issue number. |
+
+### 2. Per-issue validation (first step in `run-claude-code` job)
+
+Runs once per matrix element. Catches:
+
+| Error | Meaning |
+|-------|---------|
+| `Empty issue number passed to workflow` | A matrix element resolved to empty/whitespace. Check your comma-separated list for trailing commas. |
+| `Issue number 'X' is not a positive integer` | Non-numeric value in the issues list (e.g., `issues="abc"`). |
+| `Refusing to run against dead placeholder issue #379` | Issue #379 is a dead placeholder. See escape hatch below. |
+| `Issue #N does not exist (HTTP 404)` | The issue number doesn't exist in the repo. |
+| `Issue #N is not open (state=closed)` | The issue is closed. Only open issues are processed. |
+| `Issue #N does not have 'summit' label` | Warning only — the run proceeds but flags the missing label. |
+
+## Escape Hatch: Running Against #379
+
+Issue #379 is blocked by default because it was a dead placeholder that caused orphan runs. To intentionally run against it:
+
+1. Go to **Settings → Variables → Actions** in the `cli-anything-biddeed` repo
+2. Create or set the repository variable `ALLOW_PLACEHOLDER` to `1`
+3. Dispatch as normal with `issues=379`
+4. Remove the variable after use to re-enable the guard
+
+## Troubleshooting
+
+**Workflow completes instantly with no matrix jobs:**
+The `fromJson(format('[{0}]', inputs.issues))` expansion produced `[]`. This means the input was empty. The `validate-input` job should catch this first — if it didn't, check that `needs: validate-input` is present on the `run-claude-code` job.
+
+**Workflow fails at SSH step:**
+Not a validation issue. Check Hetzner connectivity and SSH key secrets.
+
+**Issue passes validation but Claude Code does nothing useful:**
+The issue may be open but lack actionable content. Validation confirms the issue exists and is open — it doesn't evaluate the issue body.


### PR DESCRIPTION
## Summary
- Removes `default: '379'` that caused silent orphan runs on empty API dispatch
- Adds `validate-input` gate job that fails fast on empty input before matrix expansion
- Adds per-issue pre-flight validation: empty/whitespace, non-numeric, placeholder #379 block, issue existence + open state check via GitHub API, summit label warning
- Adds `::notice::` run annotations with resolved issue numbers
- Adds `docs/SUMMIT-DISPATCH.md` with dispatch examples, error reference, and #379 escape hatch

## Test plan
- [ ] Positive smoke test: dispatch with `issues=440` — should pass validation and run
- [ ] Negative smoke test: dispatch with empty `issues=` — should fail in <30s with clear error
- [ ] Verify actionlint passes (confirmed locally)
- [ ] Confirm SUMMIT #436 unaffected

Fixes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)