### PR TITLE
feat(evolution): JsonPathEvolver — multi-LLM router for structured-config patches

### DIFF
--- a/evolution/__init__.py
+++ b/evolution/__init__.py
@@ -47,6 +47,7 @@ from .jsonpath_patcher import (
     set_path,
     coerce,
 )
+from .evolver_jsonpath import JsonPathEvolver
 from .store import EvolutionStore
 from .service import EvolutionService
 

--- a/evolution/evolver_jsonpath.py
+++ b/evolution/evolver_jsonpath.py
@@ -1,0 +1,378 @@
+# evolution/evolver_jsonpath.py
+# AUTOLOOP V2 — Structured-config patch generator (multi-LLM router)
+# Pattern source: parallel to evolver.py, but emits JsonPathEntry instead of EvolutionEntry
+# Companion to: evolution/jsonpath_patcher.py (the apply step)
+# Spec: docs/EVOLVER-JSONPATH.md
+# Issue: TBD (stacked PR on top of #7473)
+
+"""
+LLM router for STRUCTURED-CONFIG patch generation.
+
+Mirrors `Evolver` (evolver.py) but:
+  - Prompt schema is { entries: [{ field, new_value, action, reason }] }
+  - Returns list[JsonPathEntry] instead of list[EvolutionEntry]
+  - Takes a WhitelistConfig and includes it in the prompt so the LLM constrains
+    its output to patchable fields BEFORE the patcher rejects bad paths
+  - Surgical filter is COUNT-based (max_entries) instead of LINE-GROWTH-based
+    because JSON-path patches aren't measured in lines
+
+REUSE STRATEGY (avoids touching evolver.py at all — K3 surgical):
+  - `Evolver` is composed (not subclassed) for RCA-filtering + cost tracking
+  - LLM HTTP plumbing is locally duplicated (~60 LOC); if this becomes painful,
+    a separate refactor PR can extract a shared `_LlmRouter` helper
+
+WHY NOT MONKEY-PATCH EVOLVER (rejected designs):
+  - Polymorphic `generate(target_format=...)`: branches on str, return-type
+    unstable, harder to unit-test
+  - Polymorphic prompt that emits both schemas: wastes LLM tokens on irrelevant
+    section every call, and entry-counting K3 logic becomes mixed
+  - Subclass with method override: requires touching evolver.py to make
+    methods overridable
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from typing import Optional
+
+from .evolver import Evolver, _GEMINI_MODEL  # reused composition
+from .jsonpath_schema import JsonPathEntry, WhitelistConfig
+from .schema import EntryAction, EvolutionSignal, SignalType
+
+
+# ── LLM tiers (mirror evolver.py constants, kept independent for testing) ─────
+
+_DEEPSEEK_MODEL = "deepseek-chat"            # Tier 2 — primary patch generator ($0.28/1M)
+_CLAUDE_MODEL = "claude-sonnet-4-6"          # Tier 3 — quality fallback (~$3 in / $15 out per 1M)
+_MAX_ENTRIES_PER_ROUND = 2                   # match evolver.py to keep hallucination flood guard
+
+
+# ── Prompt template ───────────────────────────────────────────────────────────
+# Mirrors agentic-video-maker's gemini-critique.cjs SYSTEM_PROMPT structure +
+# evolver.py's _GENERATE_PROMPT shape. Key differences:
+#   - Output schema is {field, new_value} not {section, content}
+#   - WHITELIST_JSON is rendered into the prompt so the LLM sees what's patchable
+#   - Severity tags are kept conceptually (P0/P1/P2 → reason text) but not
+#     enforced in this schema (the patcher already does that downstream)
+
+_GENERATE_JSONPATH_PROMPT = """\
+You are a structured-config evolution engine for BidDeed.AI's AUTOLOOP V2.
+Your job is to generate JSON-path patches for a STRUCTURED CONFIG (not markdown).
+
+## SKILL NAME
+{skill_name}
+
+## TARGET CONFIG (current JSON state)
+{config_json}
+
+## DETECTED SIGNALS
+{signals_json}
+
+## SCORE CONTEXT
+{score_context}
+
+## WHITELIST (CRITICAL — patches outside this list will be silently dropped)
+{whitelist_json}
+
+## TASK
+Generate up to {max_entries} JSON-path patches that fix concrete failure modes
+detected in the signals above.
+
+Return ONLY valid JSON (no markdown fences, no prose):
+{{
+  "entries": [
+    {{
+      "field": "<dotted path matching one of the whitelist patterns>",
+      "new_value": <int|float|bool|string — must satisfy the whitelist constraint>,
+      "action": "update",
+      "reason": "<1 sentence: what signal this fixes>"
+    }}
+  ]
+}}
+
+Rules:
+- Max {max_entries} entries
+- `field` MUST match a whitelist pattern. Anything else will be dropped by the patcher.
+- `new_value` MUST be a primitive (int / float / bool / string), never an object or array.
+- Numeric values: respect the min/max bounds declared in the whitelist.
+- Enum values: must be one of the listed `values`.
+- If signals are noise or no whitelisted patch applies, return {{"entries": []}}.
+"""
+
+
+# ── JsonPathEvolver ───────────────────────────────────────────────────────────
+
+class JsonPathEvolver:
+    """
+    Generate structured-config patches via multi-LLM router.
+
+    Usage:
+        evo = JsonPathEvolver(skill_name="sentinel-thresholds")
+        wl = WhitelistConfig(
+            target="sentinel-thresholds",
+            allowed_paths={
+                r"^thresholds\\.alert_threshold$": dict(type="int", min=10, max=10000),
+            },
+        )
+        config = {"thresholds": {"alert_threshold": 100}}
+        entries = evo.generate(signals, config=config, whitelist=wl)
+        # entries: list[JsonPathEntry] ready for JsonPathPatcher.apply(config, entries)
+    """
+
+    def __init__(
+        self,
+        skill_name: Optional[str] = None,
+        gemini_api_key: Optional[str] = None,
+        deepseek_api_key: Optional[str] = None,
+        anthropic_api_key: Optional[str] = None,
+        max_entries: int = _MAX_ENTRIES_PER_ROUND,
+    ):
+        self.skill_name = skill_name or "unknown"
+        self._deepseek_key = deepseek_api_key or os.getenv("DEEPSEEK_API_KEY", "")
+        self._anthropic_key = anthropic_api_key or os.getenv("ANTHROPIC_API_KEY", "")
+        self.max_entries = max(1, min(max_entries, _MAX_ENTRIES_PER_ROUND))
+        self._total_token_cost: float = 0.0
+
+        # Compose an inner Evolver for RCA filtering. We only consume its
+        # public/internal interface for _rca_filter and _call_gemini.
+        self._inner = Evolver(
+            skill_name=skill_name,
+            gemini_api_key=gemini_api_key,
+            deepseek_api_key=deepseek_api_key,
+            anthropic_api_key=anthropic_api_key,
+            max_entries=max_entries,
+        )
+
+    @property
+    def total_token_cost(self) -> float:
+        return self._total_token_cost + self._inner.total_token_cost
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def generate(
+        self,
+        signals: list[EvolutionSignal],
+        config: dict,
+        whitelist: WhitelistConfig,
+        eval_score_before: Optional[float] = None,
+        eval_score_after: Optional[float] = None,
+    ) -> list[JsonPathEntry]:
+        """
+        1. RCA filter via Gemini Flash (free, reused from inner Evolver)
+        2. DeepSeek primary generation
+        3. Claude Sonnet fallback if DeepSeek empty
+        4. Return list[JsonPathEntry] — caller passes to JsonPathPatcher.apply()
+        """
+        if not signals:
+            return []
+
+        relevant = self._inner._rca_filter(signals)
+        if not relevant:
+            return []
+
+        score_context = self._format_score_context(eval_score_before, eval_score_after)
+
+        entries = self._call_deepseek(
+            relevant, config, whitelist, score_context, eval_score_before
+        )
+        if not entries and self._anthropic_key:
+            entries = self._call_claude(
+                relevant, config, whitelist, score_context, eval_score_before
+            )
+        return entries[: self.max_entries]
+
+    # ── Private: LLM calls ────────────────────────────────────────────────────
+
+    def _call_deepseek(
+        self,
+        signals: list[EvolutionSignal],
+        config: dict,
+        whitelist: WhitelistConfig,
+        score_context: str,
+        eval_score_before: Optional[float],
+    ) -> list[JsonPathEntry]:
+        if not self._deepseek_key:
+            return []
+        prompt = self._build_prompt(signals, config, whitelist, score_context)
+        try:
+            import httpx
+            resp = httpx.post(
+                "https://api.deepseek.com/v1/chat/completions",
+                headers={"Authorization": f"Bearer {self._deepseek_key}"},
+                json={
+                    "model": _DEEPSEEK_MODEL,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "temperature": 0.3,
+                    "max_tokens": 1024,
+                },
+                timeout=30.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            content = data["choices"][0]["message"]["content"]
+            usage = data.get("usage", {})
+            tokens = usage.get("total_tokens", 0)
+            cost = tokens * 0.00000028
+            self._total_token_cost += cost
+            return self._parse_entries(
+                content, signals=signals, model=_DEEPSEEK_MODEL,
+                token_cost=cost, eval_score_before=eval_score_before,
+            )
+        except Exception:
+            return []
+
+    def _call_claude(
+        self,
+        signals: list[EvolutionSignal],
+        config: dict,
+        whitelist: WhitelistConfig,
+        score_context: str,
+        eval_score_before: Optional[float],
+    ) -> list[JsonPathEntry]:
+        if not self._anthropic_key:
+            return []
+        prompt = self._build_prompt(signals, config, whitelist, score_context)
+        try:
+            import httpx
+            resp = httpx.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": self._anthropic_key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": _CLAUDE_MODEL,
+                    "max_tokens": 1024,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+                timeout=30.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            content = data["content"][0]["text"]
+            usage = data.get("usage", {})
+            in_tokens = usage.get("input_tokens", 0)
+            out_tokens = usage.get("output_tokens", 0)
+            cost = (in_tokens * 0.000003) + (out_tokens * 0.000015)
+            self._total_token_cost += cost
+            return self._parse_entries(
+                content, signals=signals, model=_CLAUDE_MODEL,
+                token_cost=cost, eval_score_before=eval_score_before,
+            )
+        except Exception:
+            return []
+
+    # ── Private: Prompt + Parser ──────────────────────────────────────────────
+
+    def _build_prompt(
+        self,
+        signals: list[EvolutionSignal],
+        config: dict,
+        whitelist: WhitelistConfig,
+        score_context: str,
+    ) -> str:
+        signals_json = json.dumps(
+            [
+                {
+                    "type": s.signal_type.value
+                    if isinstance(s.signal_type, SignalType)
+                    else s.signal_type,
+                    "excerpt": s.excerpt,
+                    "source": s.source,
+                }
+                for s in signals
+            ],
+            indent=2,
+        )
+        # Render the whitelist as a {pattern: constraint} dict the LLM can read.
+        # Note: regex anchors (^, $) are visible — the LLM should treat them as patterns,
+        # not literals. The prompt rules above already say "MUST match a whitelist pattern".
+        whitelist_json = json.dumps(
+            {pat: meta for pat, meta in whitelist.allowed_paths.items()},
+            indent=2,
+        )
+        # Cap config to 3K chars (parallel to evolver.py's skill_md cap).
+        config_str = json.dumps(config, indent=2)[:3000]
+        return _GENERATE_JSONPATH_PROMPT.format(
+            skill_name=self.skill_name,
+            config_json=config_str,
+            signals_json=signals_json,
+            score_context=score_context,
+            whitelist_json=whitelist_json,
+            max_entries=self.max_entries,
+        )
+
+    def _parse_entries(
+        self,
+        llm_output: str,
+        signals: list[EvolutionSignal],
+        model: str,
+        token_cost: float,
+        eval_score_before: Optional[float] = None,
+    ) -> list[JsonPathEntry]:
+        """Parse LLM JSON output → list[JsonPathEntry]. Robust against fenced output."""
+        parsed = self._parse_json(llm_output)
+        raw_entries = parsed.get("entries", [])
+        result: list[JsonPathEntry] = []
+        first_signal_id = signals[0].id if signals else None
+
+        for raw in raw_entries[: self.max_entries]:
+            field_ = raw.get("field")
+            if not field_ or not isinstance(field_, str):
+                continue
+            if "new_value" not in raw:
+                continue
+            action_str = raw.get("action", "update")
+            try:
+                action = EntryAction(action_str)
+            except ValueError:
+                action = EntryAction.UPDATE
+
+            entry = JsonPathEntry(
+                skill_name=self.skill_name,
+                target=self.skill_name,
+                field=field_,
+                new_value=raw["new_value"],
+                action=action,
+                source_signal_id=first_signal_id,
+                llm_model_used=model,
+                token_cost=token_cost / max(1, len(raw_entries)),
+                eval_score_before=eval_score_before,
+            )
+            result.append(entry)
+        return result
+
+    def _parse_json(self, text: str) -> dict:
+        """Robust JSON parser: direct → regex extract → empty dict."""
+        text = text.strip()
+        try:
+            return json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            pass
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group())
+            except (json.JSONDecodeError, ValueError):
+                pass
+        return {}
+
+    def _format_score_context(
+        self, score_before: Optional[float], score_after: Optional[float]
+    ) -> str:
+        if score_before is None and score_after is None:
+            return "No score data available."
+        if score_before is not None and score_after is not None:
+            delta = score_after - score_before
+            direction = "dropped" if delta < 0 else "improved"
+            return (
+                f"Eval score {direction} from {score_before:.1%} to {score_after:.1%} "
+                f"(Δ {delta:+.1%})"
+            )
+        if score_before is not None:
+            return f"Baseline eval score: {score_before:.1%}"
+        return f"Latest eval score: {score_after:.1%}"

--- a/evolution/tests/test_evolver_jsonpath.py
+++ b/evolution/tests/test_evolver_jsonpath.py
@@ -1,0 +1,276 @@
+"""
+Unit tests for evolution/evolver_jsonpath.py.
+
+All LLM HTTP calls are mocked — no real API traffic, no real cost.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from evolution.evolver_jsonpath import JsonPathEvolver
+from evolution.jsonpath_schema import JsonPathEntry, WhitelistConfig
+from evolution.schema import EntryAction, EvolutionSignal, SignalType
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def signals() -> list[EvolutionSignal]:
+    return [
+        EvolutionSignal(
+            signal_type=SignalType.SCORE_REGRESSION,
+            skill_name="sentinel-thresholds",
+            excerpt="Alert volume dropped 80% after threshold change; missing real failures.",
+            source="eval_runner",
+        )
+    ]
+
+
+@pytest.fixture
+def whitelist() -> WhitelistConfig:
+    return WhitelistConfig(
+        target="sentinel-thresholds",
+        allowed_paths={
+            r"^thresholds\.alert_threshold$": dict(type="int", min=10, max=10000),
+            r"^thresholds\.retry_max$":       dict(type="int", min=1, max=10),
+        },
+    )
+
+
+@pytest.fixture
+def config() -> dict:
+    return {"thresholds": {"alert_threshold": 100, "retry_max": 3}}
+
+
+# ── _parse_entries ────────────────────────────────────────────────────────────
+
+class TestParseEntries:
+    def test_well_formed_response(self, signals):
+        evo = JsonPathEvolver(skill_name="sentinel-thresholds")
+        llm_output = json.dumps({
+            "entries": [
+                {"field": "thresholds.alert_threshold", "new_value": 50,
+                 "action": "update", "reason": "alerts too quiet"}
+            ]
+        })
+        result = evo._parse_entries(
+            llm_output, signals=signals, model="deepseek-chat", token_cost=0.001,
+        )
+        assert len(result) == 1
+        assert result[0].field == "thresholds.alert_threshold"
+        assert result[0].new_value == 50
+        assert result[0].action == EntryAction.UPDATE
+        assert result[0].llm_model_used == "deepseek-chat"
+        assert result[0].source_signal_id == signals[0].id
+
+    def test_json_in_markdown_fence(self, signals):
+        evo = JsonPathEvolver(skill_name="x")
+        llm_output = '```json\n{"entries": [{"field": "a.b", "new_value": 1}]}\n```'
+        result = evo._parse_entries(llm_output, signals=signals,
+                                    model="m", token_cost=0)
+        assert len(result) == 1
+        assert result[0].field == "a.b"
+
+    def test_garbage_returns_empty(self, signals):
+        evo = JsonPathEvolver(skill_name="x")
+        assert evo._parse_entries("nonsense output", signals=signals,
+                                  model="m", token_cost=0) == []
+
+    def test_drops_missing_field(self, signals):
+        evo = JsonPathEvolver(skill_name="x")
+        llm_output = json.dumps({"entries": [{"new_value": 1}, {"field": "ok.path", "new_value": 2}]})
+        result = evo._parse_entries(llm_output, signals=signals,
+                                    model="m", token_cost=0)
+        assert len(result) == 1
+        assert result[0].field == "ok.path"
+
+    def test_drops_missing_new_value(self, signals):
+        evo = JsonPathEvolver(skill_name="x")
+        llm_output = json.dumps({"entries": [{"field": "a.b"}, {"field": "c.d", "new_value": 5}]})
+        result = evo._parse_entries(llm_output, signals=signals,
+                                    model="m", token_cost=0)
+        assert len(result) == 1
+        assert result[0].field == "c.d"
+
+    def test_invalid_action_defaults_to_update(self, signals):
+        evo = JsonPathEvolver(skill_name="x")
+        llm_output = json.dumps({"entries": [{"field": "a.b", "new_value": 1, "action": "bogus"}]})
+        result = evo._parse_entries(llm_output, signals=signals,
+                                    model="m", token_cost=0)
+        assert len(result) == 1
+        assert result[0].action == EntryAction.UPDATE
+
+    def test_respects_max_entries(self, signals):
+        evo = JsonPathEvolver(skill_name="x", max_entries=1)
+        llm_output = json.dumps({"entries": [
+            {"field": "a.b", "new_value": 1},
+            {"field": "c.d", "new_value": 2},
+        ]})
+        result = evo._parse_entries(llm_output, signals=signals,
+                                    model="m", token_cost=0)
+        assert len(result) == 1
+
+
+# ── _build_prompt ─────────────────────────────────────────────────────────────
+
+class TestBuildPrompt:
+    def test_prompt_includes_critical_sections(self, signals, whitelist, config):
+        evo = JsonPathEvolver(skill_name="sentinel-thresholds")
+        prompt = evo._build_prompt(signals, config, whitelist, score_context="No score data.")
+        # Sanity: prompt mentions key elements
+        assert "sentinel-thresholds" in prompt
+        # The whitelist regex has escaped dots, so check for the unique substrings.
+        assert "alert_threshold" in prompt              # whitelist key + config value
+        assert "retry_max" in prompt                    # whitelist key + config value
+        assert '"min": 10' in prompt                    # constraint
+        assert "score_regression" in prompt              # signal type
+        assert "WHITELIST" in prompt
+        assert "MUST match a whitelist pattern" in prompt
+
+    def test_prompt_caps_long_config(self, signals, whitelist):
+        evo = JsonPathEvolver(skill_name="x")
+        big_config = {"data": "x" * 10000}
+        prompt = evo._build_prompt(signals, big_config, whitelist, score_context="")
+        # 3000 char cap on config dump; prompt overall is bigger because of template,
+        # but the config dump section is bounded.
+        assert len(prompt) < 6000
+
+
+# ── _format_score_context ─────────────────────────────────────────────────────
+
+class TestScoreContext:
+    def test_no_scores(self):
+        evo = JsonPathEvolver(skill_name="x")
+        assert evo._format_score_context(None, None) == "No score data available."
+
+    def test_drop(self):
+        evo = JsonPathEvolver(skill_name="x")
+        msg = evo._format_score_context(0.8, 0.6)
+        assert "dropped" in msg
+        assert "80.0%" in msg and "60.0%" in msg
+
+    def test_improvement(self):
+        evo = JsonPathEvolver(skill_name="x")
+        msg = evo._format_score_context(0.5, 0.7)
+        assert "improved" in msg
+
+
+# ── generate() full path with mocked LLMs ─────────────────────────────────────
+
+class TestGenerateFullPath:
+    def _mock_httpx_response(self, json_body: dict, status: int = 200):
+        mock_resp = MagicMock()
+        mock_resp.status_code = status
+        mock_resp.json.return_value = json_body
+        mock_resp.raise_for_status.return_value = None
+        return mock_resp
+
+    @patch("httpx.post")
+    def test_deepseek_primary_returns_patches(self, mock_post, signals, whitelist, config):
+        # DeepSeek returns a valid patch
+        mock_post.return_value = self._mock_httpx_response({
+            "choices": [{"message": {"content": json.dumps({
+                "entries": [{"field": "thresholds.alert_threshold",
+                             "new_value": 50, "action": "update",
+                             "reason": "too quiet"}]
+            })}}],
+            "usage": {"total_tokens": 100},
+        })
+        evo = JsonPathEvolver(
+            skill_name="sentinel-thresholds",
+            gemini_api_key="",       # skip RCA (returns all signals)
+            deepseek_api_key="ds",
+        )
+        entries = evo.generate(signals, config=config, whitelist=whitelist)
+        assert len(entries) == 1
+        assert entries[0].field == "thresholds.alert_threshold"
+        assert entries[0].new_value == 50
+        assert evo._total_token_cost > 0
+
+    @patch("httpx.post")
+    def test_deepseek_empty_falls_back_to_claude(self, mock_post, signals, whitelist, config):
+        # First call (DeepSeek) returns garbage; second call (Claude) returns good
+        deepseek_resp = self._mock_httpx_response({
+            "choices": [{"message": {"content": "no valid json"}}],
+            "usage": {"total_tokens": 50},
+        })
+        claude_resp = self._mock_httpx_response({
+            "content": [{"text": json.dumps({
+                "entries": [{"field": "thresholds.retry_max",
+                             "new_value": 5, "action": "update",
+                             "reason": "retry too aggressive"}]
+            })}],
+            "usage": {"input_tokens": 100, "output_tokens": 50},
+        })
+        mock_post.side_effect = [deepseek_resp, claude_resp]
+
+        evo = JsonPathEvolver(
+            skill_name="sentinel-thresholds",
+            gemini_api_key="",            # skip RCA
+            deepseek_api_key="ds",
+            anthropic_api_key="ant",
+        )
+        entries = evo.generate(signals, config=config, whitelist=whitelist)
+        assert len(entries) == 1
+        assert entries[0].field == "thresholds.retry_max"
+        assert entries[0].new_value == 5
+        assert entries[0].llm_model_used == "claude-sonnet-4-6"
+        assert mock_post.call_count == 2
+
+    @patch("httpx.post")
+    def test_no_signals_short_circuits(self, mock_post, whitelist, config):
+        evo = JsonPathEvolver(skill_name="x", deepseek_api_key="ds")
+        assert evo.generate([], config=config, whitelist=whitelist) == []
+        assert mock_post.call_count == 0
+
+    @patch("httpx.post")
+    def test_no_keys_returns_empty_silently(self, mock_post, signals, whitelist, config):
+        evo = JsonPathEvolver(
+            skill_name="x",
+            gemini_api_key="",
+            deepseek_api_key="",
+            anthropic_api_key="",
+        )
+        result = evo.generate(signals, config=config, whitelist=whitelist)
+        assert result == []
+        assert mock_post.call_count == 0
+
+
+# ── Integration: generate() + JsonPathPatcher.apply() round-trip ──────────────
+
+class TestEvolveAndApplyRoundTrip:
+    """The real value: end-to-end LLM-emit → patcher-apply, no manual schema knowledge."""
+
+    @patch("httpx.post")
+    def test_evolve_then_apply_lands_change(self, mock_post, signals, whitelist, config):
+        from evolution.jsonpath_patcher import JsonPathPatcher
+
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={
+                "choices": [{"message": {"content": json.dumps({
+                    "entries": [{"field": "thresholds.alert_threshold",
+                                 "new_value": 50, "action": "update",
+                                 "reason": "too quiet"}]
+                })}}],
+                "usage": {"total_tokens": 100},
+            }),
+            raise_for_status=MagicMock(return_value=None),
+        )
+        evo = JsonPathEvolver(
+            skill_name="sentinel-thresholds",
+            gemini_api_key="",  # skip RCA
+            deepseek_api_key="ds",
+        )
+        entries = evo.generate(signals, config=config, whitelist=whitelist)
+        patcher = JsonPathPatcher(whitelist=whitelist)
+        result = patcher.apply(config, entries)
+        # The config dict was mutated in place by the patcher.
+        assert config["thresholds"]["alert_threshold"] == 50
+        assert config["thresholds"]["retry_max"] == 3  # untouched
+        assert result.total_applied == 1
+        assert result.total_skipped == 0


### PR DESCRIPTION
## ⚠️ Stacked PR — DEPENDS ON #7473

This PR is based on `feat/evolver-jsonpath-patcher` (#7473), not `main`. The diff below shows ONLY the wiring on top of the patcher. When #7473 merges to main, GitHub will auto-update this PR's base.

## What

Adds **`JsonPathEvolver`** — the multi-LLM router that produces `list[JsonPathEntry]` for the `JsonPathPatcher` introduced in #7473. Together, #7473 + this PR complete the AUTOLOOP V2 structured-config patch path:

```
signals → JsonPathEvolver.generate() → list[JsonPathEntry] → JsonPathPatcher.apply() → mutated config
        (this PR)                                            (#7473)
```

## Why composition, not modification of evolver.py

The original ask was "wire into evolver.py's LLM router." After scoring options against K3 (≤20% line growth on existing files), I picked **composition** over modification:

```yaml
rejected_alternatives:
  polymorphic_generate:
    approach: "add target_format=str param to Evolver.generate()"
    why_rejected: "unstable return-type Union[EvolutionEntry, JsonPathEntry], harder to unit-test, branches on str"
  polymorphic_prompt:
    approach: "emit both {section,content} AND {field,new_value} schemas in one prompt"
    why_rejected: "wastes LLM tokens on irrelevant section every call; mixes K3 line-growth and entry-count logic"
  subclass_with_overrides:
    approach: "class JsonPathEvolver(Evolver) override _build_prompt + _parse_entries"
    why_rejected: "requires touching evolver.py to make methods overridable + protected; K3 risk"
chosen:
  composition:
    approach: "new class wraps Evolver instance; reuses _rca_filter + cost tracking; owns its own DeepSeek/Claude HTTP paths"
    cost: "~60 LOC of LLM HTTP duplication"
    benefit: "evolver.py untouched; isolated test surface; can refactor duplication later without coordinating"
```

**evolver.py git diff vs parent branch: 0 lines.** Verified by `git diff feat/evolver-jsonpath-patcher -- evolution/evolver.py | wc -l`.

## How

```yaml
files_added:
  evolution/evolver_jsonpath.py:            378 LOC
  evolution/tests/test_evolver_jsonpath.py: 276 LOC
files_modified:
  evolution/__init__.py:                    +1 LOC  (export JsonPathEvolver)
files_untouched_K3:
  evolution/evolver.py:                     0 diff lines
  evolution/signal_detector.py:             ✓
  evolution/schema.py:                      ✓
  evolution/service.py:                     ✓
  evolution/store.py:                       ✓
  evolution/jsonpath_schema.py (from #7473):  ✓
  evolution/jsonpath_patcher.py (from #7473): ✓
```

### Prompt design

The new `_GENERATE_JSONPATH_PROMPT` template:
- Renders the **`WhitelistConfig` as a JSON dict** so the LLM sees patchable patterns + type/range/enum constraints BEFORE generating
- Instructs the LLM that `field` MUST match a whitelist pattern (defense in depth — patcher will also reject)
- Caps config dump at 3000 chars (parallel to evolver.py's SKILL.md cap)
- Asks for `{entries: [{field, new_value, action, reason}]}` shape that `_parse_entries` consumes

## Test plan

```
$ python3 -m pytest evolution/tests/ -v
======================= 52 passed, 33 warnings in 0.13s =======================
```

17 new tests (this PR) + 35 existing (from #7473):
- `_parse_entries`: 7 — well-formed, fenced JSON, garbage, missing field, missing new_value, invalid action, max_entries cap
- `_build_prompt`: 2 — critical sections present, long config capped
- `_format_score_context`: 3 — no scores / drop / improvement
- `generate()` full path (httpx mocked): 4 — DeepSeek primary, DeepSeek-empty→Claude fallback, no signals short-circuit, no keys silent return
- **End-to-end round-trip**: 1 — mocked DeepSeek emits → real `JsonPathPatcher.apply()` lands change in config dict

The round-trip test is the key proof. With both PRs landed, a single mocked LLM response flows through evolver_jsonpath.py and ends as a mutated config dict — no manual schema knowledge needed by the caller.

## Honesty (per Honesty V3)

```yaml
verified:
  - 52/52 evolution/tests/ pass on Python 3.12
  - evolver.py: 0 diff lines vs base branch (K3: 0% growth)
  - End-to-end mocked-LLM → real-patcher round-trip lands the patch
  - Fallback chain: DeepSeek empty → Claude takes over → final entry from Claude model
  - Both LLM costs tracked into self._total_token_cost (+ inner.total_token_cost from RCA)

untested:
  - Real LLM API calls (all unit tests use unittest.mock; integration deferred)
  - Behavior under real API rate-limits / 429s (timeout=30s in code but no retry logic this PR)
  - YAML configs (only JSON; trivial wrapper at load time)

inferred:
  - Prompt design will yield good whitelist-respecting outputs from DeepSeek V3.2
    (based on observed LLM behavior with similar schemas; verifiable post-merge)

assumed:
  - Inner Evolver._rca_filter remains stable across versions (private method access)
    — if it changes signature, this PR will need follow-up

not_in_scope:
  - autoloop.yml wiring (this is the *generator*; the workflow integration is a separate PR)
  - Migration for skill_evolution_jsonpath_entries table (DDL ready in #7473)
  - Per-target WhitelistConfig registry (evolution/whitelists/)
  - L3 analyzer routing (analyzer chooses markdown vs jsonpath path per skill metadata)
```

## Sequencing diagram

```mermaid
graph LR
    A[L2 eval result] --> B[L3 analyzer]
    B -->|markdown skill| C[Evolver.generate<br/>EvolutionEntry]
    B -->|structured skill| D[JsonPathEvolver.generate<br/>THIS PR<br/>JsonPathEntry]
    C --> E[SKILL.md merge]
    D --> F[JsonPathPatcher.apply<br/>#7473]
    F --> G[config dict mutated]
    E --> H[git commit + rerun eval]
    G --> H
```

Both branches feed the same downstream eval loop. The choice of generator is made by the analyzer based on skill metadata (decision logic itself is a follow-up PR).

## Reference

- Parent PR (the patcher): #7473
- L3 spec: `specs/AUTOLOOP-L3-SPEC.md`
- L3 migration applied 2026-05-12 (skill_analyses + skill_lineage tables live)
- Pattern source: Meir770ar/agentic-video-maker (MIT, REPOEVAL REFERENCE_ONLY, intake_id 01cf8cac-7a33-488a-bfdf-d0849293f1ff)