### PR TITLE
[ZW-MAPS-MCP-D4D Phase 1] Register Google Maps Platform MCP + benchmark scaffold

### DIFF
--- a/config/mcp/google-maps-platform.json
+++ b/config/mcp/google-maps-platform.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://everestcapital.usa/schemas/mcp-server-v1.json",
+  "name": "google-maps-platform",
+  "version": "1.0.0",
+  "category": "geospatial_grounding",
+  "registered_in_supabase": "mcp_servers.id=2",
+  "summit_provenance": "ZW-MAPS-MCP-D4D v2 (May 17 2026)",
+  "products_consuming": ["zonewise", "biddeed"],
+  "smart_router_tier": "flash",
+  "tier_routing_rationale": "Maps Grounding Lite returns structured place/route data; flash tier (Gemini Flash 2.5) is sufficient for orchestration. Escalation to deepseek/sonnet only when grounded result requires multi-source synthesis (e.g., parcel + zoning + comparable + Maps).",
+  "endpoints": {
+    "grounding_lite_mcp": {
+      "transport": "mcp",
+      "docs": "https://developers.google.com/maps/documentation/grounding/lite",
+      "marketing": "https://mapsplatform.google.com/maps-products/grounding/#maps-grounding-lite",
+      "status": "GA_MAY_2026"
+    },
+    "routing_grounding": {
+      "transport": "rest",
+      "status": "PRIVATE_PREVIEW",
+      "waitlist_required": true,
+      "docs": "https://mapsplatform.google.com/maps-products/grounding/"
+    },
+    "street_view_insights": {
+      "transport": "bigquery",
+      "status": "GA",
+      "requires": "BigQuery project + Gemini Enterprise Agent Platform",
+      "use_for": "D4D pre-route distress scoring (Phase 2)"
+    },
+    "places_insights": {
+      "transport": "bigquery",
+      "status": "GA",
+      "use_for": "Bulk parcel POI enrichment"
+    },
+    "address_validation": {
+      "transport": "rest",
+      "status": "GA",
+      "use_for": "Foreclosure/tax-deed scrape data quality"
+    }
+  },
+  "auth": {
+    "demo_key": {
+      "env_var": "GOOGLE_MAPS_DEMO_KEY",
+      "credit_card_required": false,
+      "signup_url": "https://mapsplatform.google.com/maps-demo-key/",
+      "rate_limits": "evaluated_at_runtime",
+      "current_status": "PENDING_HUMAN_SIGNUP (Ariel — see tracking issue)"
+    },
+    "production_key": {
+      "env_var": "GOOGLE_MAPS_API_KEY",
+      "credit_card_required": true,
+      "approval_gate": "REQUIRES_ARIEL_APPROVAL (>$10 threshold per userPreferences)"
+    }
+  },
+  "cost_ceiling": {
+    "phase_1_2_demo_key": "$0",
+    "phase_3_5_production": "$10_max_per_summit_policy",
+    "hard_breaker": "halt_and_surface_if_exceeded"
+  },
+  "phase_1_exit_criteria": {
+    "demo_key_active": "boolean — gated on human action",
+    "cost_per_lookup_ratio": "<= 1.2x current geocoding cost",
+    "latency_p99_ms": "<= 800",
+    "benchmark_table": "public.gmp_grounding_benchmarks",
+    "exit_view": "public.v_gmp_phase1_exit"
+  },
+  "human_action_items": [
+    {
+      "owner": "Ariel",
+      "action": "Claim Maps Demo Key (no credit card)",
+      "url": "https://mapsplatform.google.com/maps-demo-key/",
+      "secret_destination": "vault.secrets name=google_maps_demo_key",
+      "estimated_time_minutes": 3
+    },
+    {
+      "owner": "Ariel",
+      "action": "Register Routing Grounding Private Preview waitlist",
+      "url": "https://mapsplatform.google.com/maps-products/grounding/",
+      "estimated_time_minutes": 5
+    },
+    {
+      "owner": "Ariel",
+      "action": "Decide on Street View Insights billed-tier (Phase 2 gate, >$10)",
+      "decision_required_by": "2026-05-21"
+    }
+  ]
+}

--- a/docs/integrations/GOOGLE-MAPS-PLATFORM.md
+++ b/docs/integrations/GOOGLE-MAPS-PLATFORM.md
@@ -1,0 +1,70 @@
+# Google Maps Platform — Setup Guide (Phase 1)
+
+**Provenance:** Summit `ZW-MAPS-MCP-D4D` v2 (May 17, 2026 refresh).
+**Status:** Config-only — awaiting Demo Key from human owner.
+
+## TL;DR
+
+Google Maps Platform is registered as MCP server in Supabase (`mcp_servers.id = 2`), wired into Smart Router `flash` tier. Two endpoints are GA (Maps Grounding Lite, Maps Imagery Grounding), one is Private Preview (Routing Grounding), one needs BigQuery setup (Street View Insights — Phase 2 anchor).
+
+## Human Action Items (you, Ariel)
+
+1. **Claim Demo Key** — https://mapsplatform.google.com/maps-demo-key/ — no credit card required. Paste into Supabase vault:
+   ```sql
+   SELECT vault.create_secret('<paste-key>', 'google_maps_demo_key', 'GMP Demo Key, no-CC, rate-limited');
+   ```
+2. **Routing Preview waitlist** — https://mapsplatform.google.com/maps-products/grounding/ — fill form.
+3. **Street View Insights decision (Phase 2 gate)** — billed tier, >$10. Decide by 2026-05-21.
+
+## Smart Router Wiring
+
+- Tier: `flash` (Gemini Flash 2.5, $0.15/1M tokens)
+- Both products consume: `biddeed` + `zonewise`
+- Rationale: Grounding Lite returns structured place/route JSON; flash tier is enough to orchestrate. Escalate only on multi-source synthesis.
+
+## Phase 1 Exit Criteria
+
+| Criterion | Target | Measurement |
+|---|---|---|
+| Demo Key active | true | vault.secrets check |
+| cost_per_lookup | ≤ 1.2× current | `public.v_gmp_phase1_exit` |
+| latency_p99 | ≤ 800 ms | `public.v_gmp_phase1_exit` |
+| sample size | ≥ 200 queries / product | `public.gmp_grounding_benchmarks` |
+
+## Phase 1 Benchmark Schema
+
+```
+public.gmp_grounding_benchmarks
+  id, product (biddeed|zonewise),
+  query_text, provider (google_maps_grounding_lite|existing_geocoding|baseline_static),
+  latency_ms, freshness_seconds, cost_micro_usd,
+  returned_payload jsonb, recorded_at, source_summit_id, notes
+
+public.v_gmp_phase1_exit  -- rolling 7d aggregate, p99 + cost + pass%
+```
+
+## Endpoints Map
+
+| Endpoint | Transport | Status | Used For |
+|---|---|---|---|
+| `grounding_lite_mcp` | MCP | GA May 2026 | choropleth search, D4D NLP, parcel queries |
+| `routing_grounding` | REST | Private Preview | D4D route optimization (Phase 3) |
+| `street_view_insights` | BigQuery | GA | D4D pre-route distress scoring (Phase 2) |
+| `places_insights` | BigQuery | GA | Bulk parcel POI enrichment (Phase 4) |
+| `address_validation` | REST | GA | Foreclosure/tax-deed data quality |
+
+## Cost Posture
+
+- Phase 1–2: **$0** (Demo Key only)
+- Phase 3–5: **$10 max per summit** — hard breaker, halt & surface
+- Production key: separate approval gate, `GOOGLE_MAPS_API_KEY` env var
+
+## Hetzner Bypass Note
+
+This config was authored **directly from a Claude chat session via Supabase MCP + GitHub API**, bypassing the standard Hetzner dispatch path (OAuth on `87.99.129.125` expired 2026-05-17; second occurrence). Pattern: when Hetzner OAuth is blocked, Phase 1-style config & schema work can be executed via this short-circuit path. Phases involving sustained code generation still require Hetzner.
+
+## Files
+
+- `config/mcp/google-maps-platform.json` — canonical config (this file's sibling)
+- `docs/integrations/GOOGLE-MAPS-PLATFORM.md` — this doc
+- Supabase: `public.mcp_servers id=2`, `public.gmp_grounding_benchmarks`, `public.v_gmp_phase1_exit`


### PR DESCRIPTION
## Phase 1 of Summit ZW-MAPS-MCP-D4D (v2 May 17 refresh)

**Hetzner bypass execution** — authored directly from Claude chat session via Supabase MCP + GitHub API (Hetzner OAuth on 87.99.129.125 expired, second occurrence).

### Changes
- `config/mcp/google-maps-platform.json` — MCP server canonical config
- `docs/integrations/GOOGLE-MAPS-PLATFORM.md` — setup guide

### Supabase changes (side-effects of this PR)
- `mcp_servers.id = 2` — Google Maps Platform registered (HIGH priority, PENDING status)
- `public.gmp_grounding_benchmarks` — Phase 1 latency/cost/freshness collection table (NEW SCHEMA — flagged for review)
- `public.v_gmp_phase1_exit` — rolling 7d exit criteria aggregate view

### Blocked on human action (Ariel)
- [ ] Claim Demo Key at https://mapsplatform.google.com/maps-demo-key/ (no CC, 3 min)
- [ ] Routing Grounding Preview waitlist (5 min)
- [ ] Street View Insights billed-tier decision by 2026-05-21 (>$10 gate)

### Phase 1 exit criteria
| Criterion | Target | Status |
|---|---|---|
| Demo Key active | true | ⏳ pending human |
| cost_per_lookup | ≤ 1.2× current | ⏳ pending Demo Key |
| latency_p99 | ≤ 800 ms | ⏳ pending Demo Key |

Refs: summit_chat_dispatch e9ee6367-68f7-48c7-9ad5-7873dd88da51 · closes nothing (Phase 1 of 5)
Fixes #3345 partially.