### PR TITLE
SUMMIT 07ac31a1: add summit-biddeed-zonewise-dossier-widget.yml

### DIFF
--- a/.github/workflows/summit-biddeed-zonewise-dossier-widget.yml
+++ b/.github/workflows/summit-biddeed-zonewise-dossier-widget.yml
@@ -1,0 +1,194 @@
+name: SUMMIT - BidDeed Dossier + ZoneWise Parcel widget POC
+
+on:
+  workflow_dispatch:
+    inputs:
+      summit_id:
+        description: summit_chat_dispatch.id (UUID)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  SUPA_URL: ${{ secrets.SUPABASE_URL }}
+  SUPA_SR: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+  SUMMIT_ID: ${{ inputs.summit_id }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: SUMMIT picked_up
+        run: |
+          set -e
+          NOW=$(date -u +%FT%TZ)
+          curl -fsS -X PATCH \
+            "$SUPA_URL/rest/v1/summit_chat_dispatch?id=eq.$SUMMIT_ID" \
+            -H "apikey: $SUPA_SR" -H "Authorization: Bearer $SUPA_SR" \
+            -H "Content-Type: application/json" -H "Prefer: return=minimal" \
+            -d "{\"state\":\"picked_up\",\"picked_up_at\":\"$NOW\",\"workflow_run_id\":$GITHUB_RUN_ID,\"workflow_run_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"
+
+      - name: Fetch SUMMIT body
+        run: |
+          set -e
+          mkdir -p /tmp/summit
+          curl -fsS \
+            "$SUPA_URL/rest/v1/summit_chat_dispatch?id=eq.$SUMMIT_ID&select=summit_title,summit_body,dispatch_inputs" \
+            -H "apikey: $SUPA_SR" -H "Authorization: Bearer $SUPA_SR" \
+            > /tmp/summit/raw.json
+          jq -r '.[0].summit_body' /tmp/summit/raw.json > /tmp/summit/body.md
+
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          repository: breverdbidder/mcp-use
+          token: ${{ secrets.EVEREST_GH_PAT }}
+          path: fork
+          fetch-depth: 1
+
+      - name: Branch
+        working-directory: fork
+        run: |
+          BR="summit/${SUMMIT_ID:0:8}-widgets"
+          git config user.name "breverdbidder-bot"
+          git config user.email "bot@everestcapital.usa"
+          git checkout -b "$BR"
+          echo "BRANCH=$BR" >> $GITHUB_ENV
+
+      - name: Scaffold widget stubs (deterministic, no LLM)
+        working-directory: fork
+        run: |
+          set -e
+          mkdir -p resources/biddeed-dossier resources/zonewise-parcel
+
+          cat > resources/biddeed-dossier/widget.tsx <<'TSX'
+          import { useWidget, type WidgetMetadata } from "mcp-use/react";
+          import { z } from "zod";
+
+          const propSchema = z.object({
+            parcel_id: z.string(),
+            county: z.string(),
+            sale_date: z.string().nullable(),
+            lien_stack_usd: z.number().nullable(),
+            redemption_days_left: z.number().nullable(),
+            shapira_score: z.number().nullable(),
+          });
+
+          export const widgetMetadata: WidgetMetadata = {
+            description: "BidDeed Dossier - FL distressed parcel diligence card",
+            props: propSchema,
+          };
+
+          const BidDeedDossier: React.FC = () => {
+            const { props } = useWidget<z.infer<typeof propSchema>>();
+            return (
+              <div style={{ background: "#020617", color: "#fff", padding: 16, fontFamily: "Inter, sans-serif", borderLeft: "4px solid #1E3A5F" }}>
+                <div style={{ color: "#F59E0B", fontWeight: 700, marginBottom: 8 }}>BidDeed Dossier</div>
+                <div>Parcel {props.parcel_id} - {props.county} County, FL</div>
+                <div>Sale: {props.sale_date ?? "TBD"}</div>
+                <div>Lien Stack: {props.lien_stack_usd != null ? `$${props.lien_stack_usd.toLocaleString()}` : "-"}</div>
+                <div>Redemption: {props.redemption_days_left != null ? `${props.redemption_days_left}d left` : "-"}</div>
+                <div>Shapira Score: {props.shapira_score ?? "-"}</div>
+                {/* TODO: SEP-1865 conformance check; live Supabase fetch via tool round-trip */}
+              </div>
+            );
+          };
+
+          export default BidDeedDossier;
+          TSX
+
+          cat > resources/zonewise-parcel/widget.tsx <<'TSX'
+          import { useWidget, type WidgetMetadata } from "mcp-use/react";
+          import { z } from "zod";
+
+          const propSchema = z.object({
+            parcel_id: z.string(),
+            county: z.string(),
+            zoning_code: z.string(),
+            allowed_uses: z.array(z.string()),
+            setback_front_ft: z.number().nullable(),
+            setback_side_ft: z.number().nullable(),
+            setback_rear_ft: z.number().nullable(),
+          });
+
+          export const widgetMetadata: WidgetMetadata = {
+            description: "ZoneWise Parcel - FL 67-county zoning lookup",
+            props: propSchema,
+          };
+
+          const ZoneWiseParcel: React.FC = () => {
+            const { props } = useWidget<z.infer<typeof propSchema>>();
+            return (
+              <div style={{ background: "#020617", color: "#fff", padding: 16, fontFamily: "Inter, sans-serif", borderLeft: "4px solid #F59E0B" }}>
+                <div style={{ color: "#1E3A5F", fontWeight: 700, marginBottom: 8 }}>ZoneWise Parcel</div>
+                <div>Parcel {props.parcel_id} - {props.county} County, FL</div>
+                <div>Zoning: {props.zoning_code}</div>
+                <div>Allowed Uses: {props.allowed_uses.join(", ")}</div>
+                <div>Setbacks F/S/R: {props.setback_front_ft ?? "-"} / {props.setback_side_ft ?? "-"} / {props.setback_rear_ft ?? "-"} ft</div>
+                {/* TODO: live ZoneWise Supabase fetch; SEP-1865 conformance */}
+              </div>
+            );
+          };
+
+          export default ZoneWiseParcel;
+          TSX
+
+          cat > resources/SUMMIT_NOTES.md <<MD
+          # POC Widget Pair - SUMMIT $SUMMIT_ID
+
+          - biddeed-dossier: FL distressed parcel diligence card
+          - zonewise-parcel: FL zoning lookup (PAIRED, never ship alone)
+
+          Status: stubs scaffolded [UNTESTED]. Remaining TODOs:
+          - Live Supabase tool round-trips for both widgets
+          - SEP-1865 conformance verification
+          - Render verification in Claude + ChatGPT clients
+          MD
+
+      - name: Commit + push
+        working-directory: fork
+        run: |
+          set -e
+          git add resources/biddeed-dossier resources/zonewise-parcel resources/SUMMIT_NOTES.md
+          git commit -m "SUMMIT ${SUMMIT_ID:0:8}: scaffold biddeed-dossier + zonewise-parcel widget stubs [UNTESTED]"
+          git push origin "$BRANCH"
+
+      - name: Open draft PR
+        env:
+          GH_TOKEN: ${{ secrets.EVEREST_GH_PAT }}
+        run: |
+          set -e
+          PR_URL=$(gh pr create \
+            --repo breverdbidder/mcp-use \
+            --base main \
+            --head "$BRANCH" \
+            --title "SUMMIT ${SUMMIT_ID:0:8}: BidDeed + ZoneWise widget POC stubs" \
+            --body-file /tmp/summit/body.md \
+            --draft)
+          echo "PR_URL=$PR_URL" >> $GITHUB_ENV
+
+      - name: SUMMIT awaiting_verification (success)
+        if: success()
+        run: |
+          set -e
+          PROOF=$(jq -nc --arg pr "$PR_URL" --arg br "$BRANCH" --arg rid "$GITHUB_RUN_ID" \
+            '{pr_url:$pr, branch:$br, run_id:$rid, stubs_only:true, sep1865_verified:false, claude_chatgpt_render_verified:false}')
+          curl -fsS -X PATCH \
+            "$SUPA_URL/rest/v1/summit_chat_dispatch?id=eq.$SUMMIT_ID" \
+            -H "apikey: $SUPA_SR" -H "Authorization: Bearer $SUPA_SR" \
+            -H "Content-Type: application/json" -H "Prefer: return=minimal" \
+            -d "{\"state\":\"awaiting_verification\",\"delivery_proof\":$PROOF}"
+
+      - name: SUMMIT failed (on failure)
+        if: failure()
+        run: |
+          set -e
+          curl -fsS -X PATCH \
+            "$SUPA_URL/rest/v1/summit_chat_dispatch?id=eq.$SUMMIT_ID" \
+            -H "apikey: $SUPA_SR" -H "Authorization: Bearer $SUPA_SR" \
+            -H "Content-Type: application/json" -H "Prefer: return=minimal" \
+            -d "{\"state\":\"failed\",\"last_error\":\"workflow run $GITHUB_RUN_ID failed - see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"


### PR DESCRIPTION
## Workflow file for SUMMIT 07ac31a1

Adds `.github/workflows/summit-biddeed-zonewise-dossier-widget.yml`.

### What this workflow does
- Triggered by `workflow_dispatch` with `summit_id` input
- Pulls SUMMIT body from `summit_chat_dispatch` via Supabase REST
- Checks out `breverdbidder/mcp-use` fork
- Creates feature branch `summit/<id>-widgets`
- Scaffolds `resources/biddeed-dossier/widget.tsx` + `resources/zonewise-parcel/widget.tsx` (PAIRED) deterministically — no LLM in critical path
- Opens draft PR back to fork main
- Updates SUMMIT state to `awaiting_verification` on success or `failed` on failure

### Design decisions [VERIFIED]
- **No Claude Code**: `claude-code-direct.yml` was denylisted at 0.06% success — this workflow uses deterministic shell scaffolding instead. Widget logic (Supabase round-trips, SEP-1865 conformance) becomes a downstream SUMMIT once stubs land.
- **Draft PR on fork**, not direct push to fork main: keeps review surface
- **Pairing rule enforced**: both widget stubs scaffolded together
- **House brand colors**: Navy `#1E3A5F`, Orange `#F59E0B`, bg `#020617`, Inter

### Required secrets on this repo
- `SUPABASE_URL`
- `SUPABASE_SERVICE_ROLE_KEY`
- `EVEREST_GH_PAT`

### Cross-refs
- summit_chat_dispatch.id: `07ac31a1-b524-422e-9f72-c0daad05e54b`
- extrep_intake.id: `a792625a-9cf2-4268-80b6-dd678d1658b0`
- extrep_evaluations.id: `a596a5d4-9fa8-43aa-bbcc-f9679ee5e2bd`
- Fork: github.com/breverdbidder/mcp-use (repo_id 1251780678)